### PR TITLE
Remove 'first' from callout

### DIFF
--- a/src/routes/(nosearch)/+page.svelte
+++ b/src/routes/(nosearch)/+page.svelte
@@ -7,7 +7,7 @@
 	<h2
 		class="justify-self-center px-8 text-center text-4xl font-semibold leading-snug! md:text-5xl lg:text-6xl"
 	>
-		The first
+		The
 		<strong class="rounded-2xl bg-brand-gradient px-5 py-0 text-black">truly</strong>
 		open&nbsp;source<br />
 		search

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -16,7 +16,7 @@
 
 <svelte:head>
 	<title>MWMBL</title>
-	<meta property="og:title" content="The first truly open source search engine" />
+	<meta property="og:title" content="The truly open source search engine" />
 	<meta property="og:site_name" content="MWMBL Search Engine" />
 	<meta property="og:type" content="website" />
 	<meta


### PR DESCRIPTION
I'm not happy with calling ourselves the "first" truly open source search engine, as there have been many before.