### PR TITLE
Fix duplicate Label id

### DIFF
--- a/src/lib/components/custom/menu/Options.svelte
+++ b/src/lib/components/custom/menu/Options.svelte
@@ -54,9 +54,9 @@
 		{#if !loaded}
 			<Skeleton class="bg-input h-[24px] w-[44px] rounded-full" />
 		{:else}
-			<Switch id="newtab-switch" class="switch-fade" bind:checked={options.showVotingInterface} />
+			<Switch id="show-voting-switch" class="switch-fade" bind:checked={options.showVotingInterface} />
 		{/if}
-		<Label for="newtab-switch">Show voting interface</Label>
+		<Label for="show-voting-switch">Show voting interface</Label>
 	</div>
 </div>
 


### PR DESCRIPTION
The Switch for `Show voting interface` is using the same id of another switch 
which results in unintended behaviour (see video).

https://github.com/user-attachments/assets/d9891b15-8b52-46a8-991a-869f3e805b58

